### PR TITLE
Remove releases download, we don't need it any more

### DIFF
--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -159,10 +159,6 @@ assert-header 'Content-Type: text/plain; charset=UTF-8'
 try github-proxy.opensafely.org/bloodearnest.keys 200
 assert-in-body ed25519
 
-# test download
-try github-proxy.opensafely.org/opensafely-core/backend-server/releases/download/v0.1/test-download 200
-assert-in-body test
-
 ### docker-proxy.opensafely.org ###
 
 # test the initial docker request is rewritten correctly

--- a/github.com.conf.template
+++ b/github.com.conf.template
@@ -59,20 +59,6 @@ server {
         proxy_ssl_server_name on;
     }
 
-    # allow release artifacts to be downloaded from specified repo only
-    location ~ ^/opensafely-core/backend-server/releases/download {
-        limit_except GET { deny all; }
-        proxy_pass https://github.com;
-        proxy_redirect default;
-        # ensure Host header and SNI domain match
-        proxy_ssl_server_name on;
-        # `releases/download` redirects to an S3 bucket, which is not accessible from
-        # backends. So handle redirects to S3 here in the proxy rather than
-        # passing back to the client
-        proxy_intercept_errors on;
-        error_page 301 302 307 = @handle_redirect;
-    }
-
     location @handle_redirect {
         # set saves the initial response's Location: header
         set $redirect '$upstream_http_location';


### PR DESCRIPTION
No that https://github.com/opensafely-core/backend-server/pull/290 has landed we do not need this specific proxy route any more