### PR TITLE
Add proxies for Ubuntu APT repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ To secure and limit access to external services, the OpenSAFELY platform
 maintains a proxy service. OpenSAFELY backends explicitly use these proxies
 when they need to access external data.
 
-This repository produces a Docker image that uses nginx to host two proxy
-domains, each has their own nginx config file:
+This repository produces a Docker image that uses nginx to host four proxy
+domains, configured across three nginx config files:
 
  * github-proxy.opensafely.org: this provides access to *only* opensafely
    repositories hosted on https://github.com, and not other repositories. It
@@ -16,7 +16,12 @@ domains, each has their own nginx config file:
    Container Registry, where the docker images for running the study code are
    stored.
 
-Whilst the last one are very simple, the first two requires some shenagins in
+ * archive-ubuntu.opensafely.org and security-ubuntu.opensafely.org: this provides
+   proxy access to the Ubuntu APT repositories at http://archive.ubuntu.com and
+   http://security.ubuntu.com so that machines running within the secure environments
+   can be kept up-to-date.
+
+Whilst the last one is very simple, the first two require some shenanigans in
 order to proxy git http protocol and docker registry API v2.0 protocol.
 
 Of particular note is that ghcr.io issues 307 redirects for blob urls to

--- a/archive-ubuntu.opensafely.org.conf.template
+++ b/archive-ubuntu.opensafely.org.conf.template
@@ -1,0 +1,48 @@
+
+# Proxy the Ubuntu APT repositories to allow updates
+#
+server {
+
+    server_name archive-ubuntu.${BASE_DOMAIN};
+    root /var/www/html;
+    listen ${PORT};
+
+    location / {
+        # Dissuade naive crawlers from trying to index this site by rejecting anything
+        # which doesn't claim to be either APT or Curl (Curl, for ease of debugging).
+        # This obviously isn't intended to offer "protection" in any meaningful sense
+        # but it should be enough to prevent typical crawlers from wasting our
+        # bandwidth.
+        if ($http_user_agent !~ ^(Debian\ APT-|curl/)) {
+            return 403;
+        }
+
+        limit_except GET { deny all; }
+        proxy_pass https://archive.ubuntu.com;
+        proxy_redirect default;
+        # ensure Host header and SNI domain match
+        proxy_ssl_server_name on;
+
+
+    }
+}
+
+server {
+
+    server_name security-ubuntu.${BASE_DOMAIN};
+    root /var/www/html;
+    listen ${PORT};
+
+    location / {
+        if ($http_user_agent !~ ^(Debian\ APT-|curl/)) {
+            return 403;
+        }
+
+        limit_except GET { deny all; }
+        proxy_pass https://security.ubuntu.com;
+        proxy_redirect default;
+        proxy_ssl_server_name on;
+
+
+    }
+}

--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 BASE_DOMAIN=${BASE_DOMAIN:-opensafely.org}
 GITHUB_PROXY_HOST=github-proxy.${BASE_DOMAIN}
 DOCKER_PROXY_HOST=docker-proxy.${BASE_DOMAIN}
+UBUNTU_ARCHIVE_PROXY_HOST=archive-ubuntu.${BASE_DOMAIN}
+UBUNTU_SECURITY_PROXY_HOST=security-ubuntu.${BASE_DOMAIN}
 #CHANGELOGS_PROXY_HOST=changelogs.${BASE_DOMAIN}
 
 url=
@@ -41,6 +43,7 @@ try() {
     url=$1
     local expected=$2
     local token=${3:-}
+    local user_agent=${4:-}
 
     local curl_args=()
 
@@ -48,11 +51,18 @@ try() {
     curl_args+=(--write-out "%{http_code}")
     curl_args+=(--connect-to "${GITHUB_PROXY_HOST}:80:127.0.0.1:8080")
     curl_args+=(--connect-to "${DOCKER_PROXY_HOST}:80:127.0.0.1:8080")
+    curl_args+=(--connect-to "${UBUNTU_ARCHIVE_PROXY_HOST}:80:127.0.0.1:8080")
+    curl_args+=(--connect-to "${UBUNTU_SECURITY_PROXY_HOST}:80:127.0.0.1:8080")
     #curl_args+=(--connect-to "${CHANGELOGS_PROXY_HOST}:80:127.0.0.1:8080")
 
     # Conditionally token if set. Only used for docker-proxy tests.
     if test -n "${token}"; then
         curl_args+=(-H "Authorization: Bearer $token")
+    fi
+
+    # Conditionally set user agent; only used for APT proxy tests
+    if test -n "${user_agent}"; then
+        curl_args+=(--user-agent "$user_agent")
     fi
 
     curl_args+=("$url")         # Add the URL
@@ -200,6 +210,22 @@ digest=$(jq -r .config.digest < "$body")
 # try download a content blob, which will test our internal redirect handling,
 # including the strict ssl/host config
 try "${DOCKER_PROXY_HOST}/v2/opensafely-core/busybox/blobs/$digest?" 200 "$token"
+
+### $UBUNTU_ARCHIVE_PROXY_HOST ###
+
+try "${UBUNTU_ARCHIVE_PROXY_HOST}/ubuntu/" 200
+assert-in-body 'archive.ubuntu.com'
+assert-in-body 'dists/'
+
+try "${UBUNTU_ARCHIVE_PROXY_HOST}/ubuntu/" 403 '' 'Googlebot'
+
+### $UBUNTU_SECURITY_PROXY_HOST ###
+
+try "${UBUNTU_SECURITY_PROXY_HOST}/ubuntu/" 200
+assert-in-body 'security.ubuntu.com'
+assert-in-body 'dists/'
+
+try "${UBUNTU_SECURITY_PROXY_HOST}/ubuntu/" 403 '' 'Googlebot'
 
 ### $CHANGELOGS_PROXY_HOST ###
 # This allows us to use the do-release-upgrade tool to perform major backend OS upgrades.


### PR DESCRIPTION
Deployment required a couple of additional manual steps. First, to tell Dokku to serve the app on the two new domains:
```
dokku domains:add proxy archive-ubuntu.opensafely.org security-ubuntu.opensafely.org
```

And second to configure SSL certificates for them:
```
dokku letsencrypt:enable proxy
```